### PR TITLE
fix(CustomFields): return data for repeater fields nested inside a repeater

### DIFF
--- a/theme/classes/Utils/CustomFields.php
+++ b/theme/classes/Utils/CustomFields.php
@@ -299,8 +299,16 @@ class CustomFields
 
       $values = array_map(function ($key) use ($wp_post, $fields) {
         $values = array_map(function ($field) use ($wp_post, $key) {
+          $sub_name = "{$key}_{$field}";
+
+          // A nested repeater keeps its values under its own item keys, so it
+          // has to be read back as a repeater instead of as a single value.
+          $value = $wp_post->__get("{$sub_name}_keys")
+            ? self::get_field($sub_name, null, $wp_post)
+            : $wp_post->__get($sub_name);
+
           return [
-            $field => $wp_post->__get("{$key}_{$field}"),
+            $field => $value,
           ];
         }, $fields);
 
@@ -313,6 +321,46 @@ class CustomFields
     } else {
       return $wp_post->__get($name) ?: $fallback_value;
     }
+  }
+
+  /**
+   * Whether a repeater item was submitted with a non-empty value.
+   *
+   * @param string $key    The repeater item key.
+   * @param array  $fields The array of sub fields.
+   *
+   * @return bool
+   */
+  private static function has_submitted_value(string $key, array $fields): bool
+  {
+    foreach ($fields as $field) {
+      $name = "{$key}_{$field['name']}";
+      $type = $field['type'] ?? 'text';
+
+      if ('repeater' === $type) {
+        // A nested repeater posts its values under its own item keys rather
+        // than under $name, so the check has to follow it one level deeper.
+        $sub_keys = json_decode(stripslashes($_POST["{$name}_keys"] ?? ''), true) ?: [];
+
+        foreach ($sub_keys as $sub_key) {
+          if (self::has_submitted_value($sub_key, $field['fields'] ?? [])) {
+            return true;
+          }
+        }
+      } elseif ('group' === $type) {
+        if (self::has_submitted_value($name, $field['fields'] ?? [])) {
+          return true;
+        }
+      } else {
+        $value = $_POST[$name] ?? '';
+
+        if (! empty($value) && 'false' !== $value) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   /**
@@ -347,14 +395,8 @@ class CustomFields
           // Filter keys with non-empty fields
           $keys = json_decode(stripslashes($_POST["{$name}_keys"] ?? ''), true) ?: [];
 
-          $keys = array_filter($keys, function ($key) use ($sub_fields) {
-            $valid_fields = array_filter($sub_fields, function ($sub_field) use ($key) {
-              $value = $_POST["{$key}_{$sub_field}"];
-
-              return ! empty($value) && "false" !== $value;
-            });
-
-            return ! empty($valid_fields);
+          $keys = array_filter($keys, function ($key) use ($field) {
+            return self::has_submitted_value($key, $field['fields'] ?? []);
           });
 
           if (! empty($keys)) {


### PR DESCRIPTION
This PR proposes a fix for `CustomFields::get_field()` so a repeater field nested inside another repeater returns its items instead of an empty value (Fixes #38). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/429. You can sign in with your GitHub ID to claim ownership of the project.

## What goes wrong

`save_fields()` already handles nesting correctly: it recurses into every repeater item key, so a child repeater lands in post meta as `{item_key}_{child}_keys`, `{item_key}_{child}_fields` and one row per leaf value. `get_field()` never makes the matching walk back out — for each entry in `{$name}_fields` it reads a single meta value at `{$key}_{$field}`, and a nested repeater has nothing stored under that name. The rows are on disk the whole time; the template simply cannot reach them, so `$item['icons']` comes back empty.

The same assumption costs a second thing on the way in. `save_fields()` decides whether a repeater item is worth persisting by testing `$_POST["{$key}_{$sub_field}"]` for each declared sub-field, but a nested repeater posts `{$key}_{$sub_field}_keys` plus its own item keys rather than that name, so it always reads as empty. A parent item whose only content is a nested repeater is therefore discarded on save, and PHP 8 emits `Warning: Undefined array key` for that sub-field every time the meta box is saved.

## Reproducing on `dev` at fee217d

```php
$fields = [[
  'name' => 'features', 'type' => 'repeater',
  'fields' => [
    ['name' => 'title', 'type' => 'text'],
    ['name' => 'icons', 'type' => 'repeater', 'fields' => [['name' => 'icon', 'type' => 'text']]],
  ],
]];

$_POST = [
  'section_1_features_keys'           => '["section_1_features_0"]',
  'section_1_features_0_title'        => 'Fast',
  'section_1_features_0_icons_keys'   => '["section_1_features_0_icons_0"]',
  'section_1_features_0_icons_0_icon' => 'bolt',
];

(new CustomFields())->save_fields($post_id, $fields, 'section_1');
print_r(CustomFields::get_field('section_1_features', null, get_post($post_id)));
```

Run with `wp eval-file` against this theme in a WordPress install, on `dev` at fee217d:

```
Warning: Undefined array key "section_1_features_0_icons" in .../classes/Utils/CustomFields.php on line 352
Array
(
    [0] => Array
        (
            [icons] =>
            [title] => Fast
        )

)
```

`section_1_features_0_icons_keys` and `section_1_features_0_icons_0_icon` are both sitting in `wp_postmeta` at that point, so nothing was lost on the way in for this shape — only on the way out.

## The change

`get_field()` now looks for a `{$sub_name}_keys` row before reading a sub-field, and when one exists it reads that sub-field through `get_field()` itself — the same branch it already takes at the top level, which makes nesting work at any depth. A sub-field with no `_keys` row goes through the identical `__get()` call it did before, so a plain text, image or checkbox entry still returns exactly what it returned previously, including `''` rather than `null` when it is unset.

The emptiness test in `save_fields()` moves into `has_submitted_value()`, which applies the existing `! empty($value) && 'false' !== $value` rule to plain sub-fields and walks into nested repeaters and groups instead of looking for a value that was never posted under that name. It is strictly more permissive than the check it replaces — every item kept before is still kept — so "prevent saving repeater items with all empty fields" continues to hold, and the undefined-key warning is gone. The same snippet, with this change applied:

```
Array
(
    [0] => Array
        (
            [icons] => Array
                (
                    [0] => Array
                        (
                            [icon] => bolt
                        )

                )

            [title] => Fast
        )

)
```

## Verification

- Sixteen assertions were run against a real WordPress and MySQL install with this theme's `CustomFields` loaded. On `dev` two of them fail — three levels of repeater nesting, and a `group` nested inside a repeater item — both alongside the undefined-key warning. With this change all sixteen pass and the warning is gone. The other fourteen are the controls and behave identically on both trees: flat repeaters, all-empty items still dropped, an unchecked checkbox still treated as empty, groups still readable at their flat leaf names, an empty sub-field inside an item still `''` and not `null`, and an empty nested repeater not resurrecting an item that would otherwise be discarded.
- `php -l` over every file in `theme/`, before and after: no syntax failures either way.
- `php-cs-fixer` using the repo's own `.php-cs-fixer.dist.php`: the set of files it reports as fixable is identical before and after, and `CustomFields.php` is not in it.

## How this was managed

We tracked this work on a board built from this repository's own issues and pull requests, 47 stories in all. The story it was done under is [Repeater field nested inside another repeater does not return data](https://eastagiletracker.com/projects/429/stories/384622), on the board at https://eastagiletracker.com/projects/429.

![board](https://raw.githubusercontent.com/eastagiletracker/wplite/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
